### PR TITLE
Update PkgSigner.py

### DIFF
--- a/PkgSigner/PkgSigner.py
+++ b/PkgSigner/PkgSigner.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-import FoundationPlist
+import plistlib
 import subprocess
 import os
 


### PR DESCRIPTION
Switched foundationplist module for plistlib as it is the new "standard" for autopkg and fonduationplist is no longer included AFAIK